### PR TITLE
Use relative paths instead of absolute ones

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>RVMM Config Generator</title>
-  <script type="module" crossorigin src="/rvmm-config-gen/assets/index-9403d969.js"></script>
-  <link rel="stylesheet" href="/rvmm-config-gen/assets/index-e7f895a0.css">
+  <script type="module" crossorigin src="assets/index-9403d969.js"></script>
+  <link rel="stylesheet" href="assets/index-e7f895a0.css">
 </head>
 
 <body>


### PR DESCRIPTION
In index.html file js and css script file paths are absolute to what I think it's a jekyll container used by github actions to build github pages website.
This gave me problems while trying to serve the same website using my own container.

I think it would be better to use a path relative to the file location or repository, what do you think? Is there a reason why those paths are absolute?

Thanks for your time.

Best Regards,
lotation